### PR TITLE
Added support for query string syntax array/object fields in multipart

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1,5 +1,6 @@
 var http = require('http');
 var escape = require('querystring').escape;
+var parse = require('./parse');
 
 // TODO: Benchmark zlib performance against node-compress.
 var zlib = require('zlib');
@@ -91,47 +92,6 @@ if (!requestProto.hasOwnProperty('cookies')) {
       return cookies;
     }
   });
-}
-
-function parse(string) {
-  var data;
-  if (typeof string == 'string') {
-    if (string[0] == '{') {
-      try {
-        data = JSON.parse(string);
-      }
-      catch (e) {
-        this.logger.error(e.stack);
-        this.logger.log(buffer);
-      }
-    }
-    else {
-      data = {};
-      string.split('&').forEach(function (pair) {
-        pair = pair.split('=');
-        var key = decodeURIComponent(pair[0]);
-        var value = decodeURIComponent(pair[1]);
-        var isObjectOrArray = false;
-        var subKey = null;
-        key = key.replace(/\[([^\]]*)\]$/, function (match, inner) {
-          isObjectOrArray = true;
-          subKey = inner;
-          return '';
-        });
-        if (key) {
-          if (isObjectOrArray) {
-            data[key] = data[key] || ((subKey && isNaN(subKey)) ? {} : []);
-            subKey = subKey || data[key].length;
-            data[key][subKey] = value;
-          }
-          else {
-            data[key] = value;
-          }
-        }
-      });
-    }
-  }
-  return data || {};
 }
 
 if (!requestProto.hasOwnProperty('query')) {

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -1,3 +1,5 @@
+var parse = require('./parse');
+
 function isBr(n) {
   return n == 13 || n == 10;
 }
@@ -147,7 +149,7 @@ module.exports = function (request, response, maxBytes) {
     }
     else {
       data += d;
-      request.multipart[field.name] = data;
+      parse.applyPair(request.multipart, field.name, data);
     }
   }
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,0 +1,51 @@
+/**
+ * Rudimentary query string parser.
+ */
+var parse = module.exports = function (string) {
+  var object;
+  if (typeof string == 'string') {
+    if (string[0] == '{') {
+      try {
+        object = JSON.parse(string);
+      }
+      catch (e) {
+        this.logger.error(e.stack);
+        this.logger.log(buffer);
+      }
+    }
+    else {
+      object = {};
+      string.split('&').forEach(function (pair) {
+        pair = pair.split('=');
+        var key = decodeURIComponent(pair[0]);
+        var value = decodeURIComponent(pair[1]);
+        parse.applyPair(object, key, value);
+      });
+    }
+  }
+  return object || {};
+};
+
+/**
+ * Add a key-value pair to an object, coping with query string syntax.
+ */
+parse.applyPair = function (object, key, value) {
+  var isObjectOrArray = false;
+  var subKey = null;
+  // TODO: Add support for deep nesting.
+  key = key.replace(/\[([^\]]*)\]$/, function (match, inner) {
+    isObjectOrArray = true;
+    subKey = inner;
+    return '';
+  });
+  if (key) {
+    if (isObjectOrArray) {
+      object[key] = object[key] || ((subKey && isNaN(subKey)) ? {} : []);
+      subKey = subKey || object[key].length;
+      object[key][subKey] = value;
+    }
+    else {
+      object[key] = value;
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "za"
   ],
-  "version": "0.0.20",
+  "version": "0.0.21",
   "main": "za.js",
   "homepage": "http://github.com/lighterio/za",
   "repository": "http://github.com/lighterio/za.git",
@@ -44,6 +44,6 @@
     "qs": "0.6.6",
     "supertest": "0.13.0",
     "zeriousify": "0.1.7",
-    "exam": "0.0.6"
+    "exam": "0.0.7"
   }
 }


### PR DESCRIPTION
Previously, query strings could have syntaxes such as "collection[]=blah", and URLs would respect this, but multipart fields wouldn't. This pull fixes that problem.

NOTE: The parser should be made to support multiply-nested collections in the future.
