### PR TITLE
Added app.unuse

### DIFF
--- a/lib/Router.js
+++ b/lib/Router.js
@@ -34,22 +34,22 @@ module.exports = function Router(protocol) {
   // Middlewares are functions that chain asynchronously.
   var middlewares = this.middlewares = [];
 
-  this.setApp = function setApp(value) {
+  this.setApp = function (value) {
     app = this.app = value;
   };
 
-  this.setPort = function setPort(port) {
+  this.setPort = function (port) {
     this.port = port;
   };
 
-  this.setServer = function setServer(server) {
+  this.setServer = function (server) {
     this.server = server;
   };
 
   /**
    * Add a function to handle a specific HTTP method and URL path.
    */
-  this.add = function add(method, path, fn) {
+  this.add = function (method, path, fn) {
     method = method.toUpperCase();
     path = patternify(path, '^', '$');
     var map = routes[method] = routes[method] || [];
@@ -68,7 +68,7 @@ module.exports = function Router(protocol) {
   /**
    * Add a middleware, with an optional path.
    */
-  this.use = function use(path, fn) {
+  this.use = function (path, fn) {
     var middleware;
     if (typeof path == 'function') {
       middleware = path;
@@ -87,8 +87,21 @@ module.exports = function Router(protocol) {
           return isMatch ? fn.apply(app, arguments) : true;
         };
       }
+      middleware.fn = fn;
     }
     middlewares.push(middleware);
+  };
+
+  /**
+   * Remove a middleware, regardless of path.
+   */
+  this.unuse = function (fn) {
+    for (var i = 0; i < middlewares.length; i++) {
+      var middleware = middlewares[i];
+      if ((fn == middleware) || (fn == middleware.fn)) {
+        middlewares.splice(i--, 1);
+      }
+    }
   };
 
   /**

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -87,6 +87,16 @@ var proto = Server.prototype = {
   },
 
   /**
+   * Remove a middleware function from usage.
+   */
+  unuse: function (fn, protocol) {
+    this.routers(protocol).forEach(function (router) {
+      router.unuse(fn);
+    });
+    return this;
+  },
+
+  /**
    * Listen for HTTP/HTTPS requests based on a `config` object.
    * For example:
    * ```json

--- a/test/middlewareTest.js
+++ b/test/middlewareTest.js
@@ -1,0 +1,57 @@
+var http = require('http');
+var Server = require('../lib/Server');
+var app;
+
+// TODO: Move middleware-related tests here.
+describe('Middleware', function () {
+
+  before(function () {
+    app = new Server({http: 9876});
+  });
+
+  after(function () {
+    app.close();
+  });
+
+  it('gets added with .use()', function (done) {
+    var count = 0;
+    app.use('/test', function (request, response, next) {
+      count++;
+      next();
+    });
+    app.get('/test/ok', function (request, response) {
+      response.end('ok' + count);
+    });
+    http
+      .get('http://127.0.0.1:9876/test/ok', function (response) {
+        response.on('data', function (data) {
+          is('ok1', '' + data);
+          done();
+        });
+      })
+      .on('error', done);
+  });
+
+  it('gets removed with .unuse()', function (done) {
+    var count = 0;
+    var middleFn = function (request, response, next) {
+      count++;
+      is.fail('Should not get here!');
+      next();
+    };
+    app.use('/untest', middleFn);
+    app.unuse(middleFn);
+    app.get('/untest/ok', function (request, response) {
+      response.end('ok' + count);
+    });
+    http
+      .get('http://127.0.0.1:9876/untest/ok', function (response) {
+        response.on('data', function (data) {
+          is('ok0', '' + data);
+          done();
+        });
+      })
+      .on('error', done);
+  });
+
+});

--- a/za.js
+++ b/za.js
@@ -6,8 +6,8 @@ require('./lib/Response');
 var Server = require('./lib/Server');
 
 // The API is a function which returns a server.
-var za = module.exports = function () {
-  return new Server();
+var za = module.exports = function (config) {
+  return new Server(config);
 };
 
 // Expose the version number, but only load package JSON if a get is performed.


### PR DESCRIPTION
Lighter needs a way to remove middlewares from Za so that we can catch all requests that happen before a Lighter server is ready.
